### PR TITLE
Aplicar uma cor de fundo no botão de reiniciar

### DIFF
--- a/jogodavelha.css
+++ b/jogodavelha.css
@@ -111,5 +111,6 @@ span{
     cursor: pointer;
     border: none;
     box-shadow: 0;
+    background-color: white;
 }
 


### PR DESCRIPTION
No Safari o botão reiniciar perde o estilo padrão quando aplicamos a borda arredondada, por isso a cor de fundo ficava transparente. Aplicando a cor branca, ele vai voltar a aprecer.

Antes | Depois
-|-
![botao-sumido](https://user-images.githubusercontent.com/4405147/80282828-dbcd1380-8713-11ea-9a8d-46c49f79ad16.png)|![botao-reiniciar](https://user-images.githubusercontent.com/4405147/80282801-bd671800-8713-11ea-90d8-1e937b7f4c9d.png)
